### PR TITLE
pin aws-provider version for terraform deployment

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -5,6 +5,7 @@ data "aws_region" "current" {
 # Configure the AWS Provider
 provider "aws" {
   region = "us-east-1"
+  version = "<= 5.8.0"
 }
 
 variable "environment_name" {


### PR DESCRIPTION
as we identified an issue with aws-provider `v5.9.0`, we are pinning the provider to a smaller version for now.