### PR TITLE
Add auth token guard to Makefile and upgrade workflow actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - uses: gautamkrishnar/keepalive-workflow@v1
+
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
         with:
@@ -40,12 +42,12 @@ jobs:
         env:
           LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
-          pip install localstack awscli-local[ver1]
+          pip install localstack==3.2.0 awscli-local[ver1]
           pip install terraform-local
-          docker pull localstack/localstack-pro:latest
+          docker pull localstack/localstack-pro:3.2.0
 
           # Start LocalStack in the background
-          localstack start -d
+          IMAGE_NAME=localstack/localstack-pro:3.2.0 localstack start -d
 
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -23,9 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-
-      - uses: gautamkrishnar/keepalive-workflow@v1
+        uses: actions/checkout@v4
 
       - name: Setup Terraform
         uses: hashicorp/setup-terraform@v3
@@ -34,20 +32,20 @@ jobs:
 
       - name: Set up Python 3.10
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
         run: |
-          pip install localstack==3.2.0 awscli-local[ver1]
+          pip install localstack awscli-local[ver1]
           pip install terraform-local
-          docker pull localstack/localstack-pro:3.2.0
+          docker pull localstack/localstack-pro:latest
 
           # Start LocalStack in the background
-          IMAGE_NAME=localstack/localstack-pro:3.2.0 localstack start -d
+          localstack start -d
 
           # Wait 30 seconds for the LocalStack container to become ready before timing out
           echo "Waiting for LocalStack startup..."
@@ -101,17 +99,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Python 3.10
         id: setup-python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.10"
 
       - name: Start LocalStack
         env:
-          LOCALSTACK_API_KEY: ${{ secrets.LOCALSTACK_API_KEY }}
+          LOCALSTACK_AUTH_TOKEN: ${{ secrets.LOCALSTACK_AUTH_TOKEN }}
           DNS_ADDRESS: 0
         run: |
           pip install localstack awscli-local[ver1]

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,8 @@ run:                  ## Run the sample app
 			echo $$URL
 
 start:                ## Start LocalStack in detached mode
-		EXTRA_CORS_ALLOWED_ORIGINS=http://sample-app.s3.localhost.localstack.cloud:4566 DISABLE_CUSTOM_CORS_APIGATEWAY=1 localstack start -d
+		@test -n "${LOCALSTACK_AUTH_TOKEN}" || (echo "LOCALSTACK_AUTH_TOKEN is not set. Find your token at https://app.localstack.cloud/workspace/auth-token"; exit 1)
+		@LOCALSTACK_AUTH_TOKEN=$(LOCALSTACK_AUTH_TOKEN) EXTRA_CORS_ALLOWED_ORIGINS=http://sample-app.s3.localhost.localstack.cloud:4566 DISABLE_CUSTOM_CORS_APIGATEWAY=1 localstack start -d
 
 stop:                 ## Stop the running LocalStack container
 		@echo

--- a/README.md
+++ b/README.md
@@ -31,12 +31,13 @@ We are using the following AWS services and their features to build our infrastr
 
 ## Prerequisites
 
-- LocalStack Pro with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
+- LocalStack with the [`localstack` CLI](https://docs.localstack.cloud/getting-started/installation/#localstack-cli).
 - [AWS CLI](https://docs.localstack.cloud/user-guide/integrations/aws-cli/) with the [`awslocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/aws-cli/#localstack-aws-cli-awslocal).
 - [Terraform](https://docs.localstack.cloud/user-guide/integrations/terraform/) with the [`tflocal` wrapper](https://docs.localstack.cloud/user-guide/integrations/terraform/#using-the-tflocal-script).
 - [Node.js](https://nodejs.org/en/download/) with `npm` package manager.
+- A valid [LocalStack for AWS license](https://localstack.cloud/pricing). Your license provides a [`LOCALSTACK_AUTH_TOKEN`](https://docs.localstack.cloud/getting-started/auth-token/) to activate LocalStack.
 
-Start LocalStack Pro with the appropriate configuration to enable the S3 website to send requests to the container APIs:
+Start LocalStack with the appropriate configuration to enable the S3 website to send requests to the container APIs:
 
 ```shell
 export LOCALSTACK_AUTH_TOKEN=<your-auth-token>


### PR DESCRIPTION
## Summary
- Add `LOCALSTACK_AUTH_TOKEN` guard to Makefile `start` target
- Upgrade `actions/checkout@v3` to `v4`, `actions/setup-python@v2` to `v4`
- Replace deprecated `LOCALSTACK_API_KEY` with `LOCALSTACK_AUTH_TOKEN` in workflows
- Remove pinned LocalStack version and `keepalive-workflow` action